### PR TITLE
returning a string field as array breaks Restful Server

### DIFF
--- a/code/extensions/MemberProfileExtension.php
+++ b/code/extensions/MemberProfileExtension.php
@@ -12,7 +12,7 @@ class MemberProfileExtension extends DataObjectDecorator {
 			'db' => array (
 				'ValidationKey'   => 'Varchar(40)',
 				'NeedsValidation' => 'Boolean',
-				'PublicFields'    => 'Text'
+				'PublicFieldsRaw'    => 'Text'
 			),
 			'has_one' => array (
 				'ProfilePage' => 'MemberProfilePage'
@@ -21,11 +21,11 @@ class MemberProfileExtension extends DataObjectDecorator {
 	}
 
 	public function getPublicFields() {
-		return (array) unserialize($this->owner->getField('PublicFields'));
+		return (array) unserialize($this->owner->getField('PublicFieldsRaw'));
 	}
 
 	public function setPublicFields($fields) {
-		$this->owner->setField('PublicFields', serialize($fields));
+		$this->owner->setField('PublicFieldsRaw', serialize($fields));
 	}
 
 	public function canLogIn($result) {


### PR DESCRIPTION
MemberProfiles causes error in sapphire/api/XMLDataFormatter.php 

   [Warning] mb_check_encoding() expects parameter 1 to be string, array given

because DB Field is declared as Text, but getter returns array.

All I did was rename the DB field. Hopefully the rest of your module uses the getter/setter. No idea if this actually breaks anything or not!!

Cheers,

Barry. 
