### PR TITLE
Added ability to specify the URL to use for redirectBack()

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -488,6 +488,15 @@ class MemberProfilePage_Controller extends Page_Controller {
 		}
 	}
 
+	public function redirectBack() {
+		if( $url = $this->request->requestVar('redirectBackURL') ) {
+			return $this->redirect($url);
+		}
+		else {
+			return $this->redirectBack();
+		}
+	}
+
 	/**
 	 * Returns the after registration content to the user.
 	 *


### PR DESCRIPTION
Added ability to specify the URL to use for redirectBack(). This was added so that you can have a form on another (non-MemberProfilePage) page that submits to the MemberProfilePage. Currently if this has a validation error then it redirects back to the previous page but we can't display validation errors there. So we want it to redirect to the MemberProfilePage in the case of validation errors. This change allows you to specify a redirectBackURL request parameter to control where it redirects to.
