### PR TITLE
BUGFIX don't use static function for Security::Link()

### DIFF
--- a/code/email/MemberConfirmationEmail.php
+++ b/code/email/MemberConfirmationEmail.php
@@ -83,13 +83,13 @@ class MemberConfirmationEmail extends Email {
 	public static function get_parsed_string($string, $member, $page) {
 		$variables = array (
 			'$SiteName'       => SiteConfig::current_site_config()->Title,
-			'$LoginLink'      => Director::absoluteURL(Security::Link('login')),
+			'$LoginLink'      => Director::absoluteURL(singleton('Security')->Link('login')),
 			'$ConfirmLink'    => Director::absoluteURL(Controller::join_links (
 				$page->Link('confirm'),
 				$member->ID,
 				"?key={$member->ValidationKey}"
 			)),
-			'$LostPasswordLink' => Director::absoluteURL(Security::Link('lostpassword')),
+			'$LostPasswordLink' => Director::absoluteURL(singleton('Security')->Link('lostpassword')),
 			'$Member.Created'   => $member->obj('Created')->Nice()
 		);
 


### PR DESCRIPTION
The static method does not exist
