### PR TITLE
API: updated to ss 3.1

### DIFF
--- a/code/MemberProfileField.php
+++ b/code/MemberProfileField.php
@@ -4,7 +4,7 @@
  */
 class MemberProfileField extends DataObject {
 
-	public static $db = array (
+	private static $db = array (
 		'ProfileVisibility'       => 'Enum("Edit, Readonly, Hidden", "Hidden")',
 		'RegistrationVisibility'  => 'Enum("Edit, Readonly, Hidden", "Hidden")',
 		'MemberListVisible'       => 'Boolean',
@@ -20,11 +20,11 @@ class MemberProfileField extends DataObject {
 		'Sort'                    => 'Int'
 	);
 
-	public static $has_one = array (
+	private static $has_one = array (
 		'ProfilePage' => 'MemberProfilePage'
 	);
 
-	public static $summary_fields = array (
+	private static $summary_fields = array (
 		'DefaultTitle'           => 'Field',
 		'ProfileVisibility'      => 'Profile Visibility',
 		'RegistrationVisibility' => 'Registration Visibility',
@@ -33,7 +33,7 @@ class MemberProfileField extends DataObject {
 		'Required'               => 'Required'
 	);
 
-	public static $default_sort = 'Sort';
+	private static $default_sort = 'Sort';
 
 	/**
 	 * Temporary local cache of form fields - otherwise we can potentially be calling
@@ -184,7 +184,7 @@ class MemberProfileField extends DataObject {
 	public function isAlwaysRequired() {
 		return in_array (
 			$this->MemberField,
-			array(Member::get_unique_identifier_field(), 'Password')
+			array(Config::inst()->get('Member', 'unique_identifier_field'), 'Password')
 		);
 	}
 
@@ -192,7 +192,7 @@ class MemberProfileField extends DataObject {
 	 * @return bool
 	 */
 	public function isAlwaysUnique() {
-		return $this->MemberField == Member::get_unique_identifier_field();
+		return $this->MemberField == Config::inst()->get('Member', 'unique_identifier_field');
 	}
 
 	/**

--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -13,7 +13,7 @@
  */
 class MemberProfilePage extends Page implements PermissionProvider {
 
-	public static $db = array (
+	private static $db = array (
 		'ProfileTitle'             => 'Varchar(255)',
 		'RegistrationTitle'        => 'Varchar(255)',
 		'AfterRegistrationTitle'   => 'Varchar(255)',
@@ -34,22 +34,22 @@ class MemberProfilePage extends Page implements PermissionProvider {
 		'ConfirmationContent'      => 'HTMLText'
 	);
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'PostRegistrationTarget' => 'SiteTree',
 	);
 
-	public static $has_many = array (
+	private static $has_many = array (
 		'Fields'   => 'MemberProfileField',
 		'Sections' => 'MemberProfileSection'
 	);
 
-	public static $many_many = array (
+	private static $many_many = array (
 		'Groups'           => 'Group',
 		'SelectableGroups' => 'Group',
 		'ApprovalGroups'   => 'Group'
 	);
 
-	public static $defaults = array (
+	private static $defaults = array (
 		'ProfileTitle'             => 'Edit Profile',
 		'RegistrationTitle'        => 'Register / Log In',
 		'AfterRegistrationTitle'   => 'Registration Successful',
@@ -85,9 +85,9 @@ class MemberProfilePage extends Page implements PermissionProvider {
 			'ProfileVisibility'      => 'Edit')
 	);
 
-	public static $description = '';
+	private static $description = '';
 
-	public static $icon = 'memberprofiles/images/memberprofilepage.png';
+	private static $icon = 'memberprofiles/images/memberprofilepage.png';
 
 	/**
 	 * If profile editing is disabled, but the current user can add members,
@@ -361,7 +361,7 @@ class MemberProfilePage extends Page implements PermissionProvider {
  */
 class MemberProfilePage_Controller extends Page_Controller {
 
-	public static $allowed_actions = array (
+	private static $allowed_actions = array (
 		'index',
 		'RegisterForm',
 		'afterregistration',

--- a/code/controllers/MemberApprovalController.php
+++ b/code/controllers/MemberApprovalController.php
@@ -4,11 +4,11 @@
  */
 class MemberApprovalController extends Page_Controller {
 
-	public static $url_handlers = array(
+	private static $url_handlers = array(
 		'$ID' => 'index'
 	);
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index'
 	);
 

--- a/code/controllers/MemberProfileViewer.php
+++ b/code/controllers/MemberProfileViewer.php
@@ -7,7 +7,7 @@
  */
 class MemberProfileViewer extends Page_Controller {
 
-	public static $url_handlers = array(
+	private static $url_handlers = array(
 		''           => 'handleList',
 		'$MemberID!' => 'handleView'
 	);

--- a/code/dataobjects/MemberProfileSection.php
+++ b/code/dataobjects/MemberProfileSection.php
@@ -7,19 +7,19 @@
  */
 class MemberProfileSection extends DataObject {
 
-	public static $db = array(
+	private static $db = array(
 		'CustomTitle' => 'Varchar(100)'
 	);
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'Parent' => 'MemberProfilePage'
 	);
 
-	public static $extensions = array(
+	private static $extensions = array(
 		// 'Orderable'
 	);
 
-	public static $summary_fields = array(
+	private static $summary_fields = array(
 		'DefaultTitle' => 'Title',
 		'CustomTitle'  => 'Custom Title'
 	);

--- a/code/extensions/MemberProfileExtension.php
+++ b/code/extensions/MemberProfileExtension.php
@@ -7,14 +7,14 @@
  */
 class MemberProfileExtension extends DataExtension {
 
-	public static $db = array(
+	private static $db = array(
 		'ValidationKey'   => 'Varchar(40)',
 		'NeedsValidation' => 'Boolean',
 		'NeedsApproval'   => 'Boolean',
 		'PublicFieldsRaw' => 'Text'
 	);
 
-	public static $has_one = array(
+	private static $has_one = array(
 	'ProfilePage' => 'MemberProfilePage'
 	);
 


### PR DESCRIPTION
because of the radical API changes in 3.1 modules that use any silverstripe statics (like $db) can no longer be compatible with 3.0 and 3.1 at the same time.

therefore I suggest creating a 3.0 (name can differ, but I have seen other modules use 3.0) branch from the current master
and after that merge this pull request to make branch master compatible with silverstripe master
