### PR TITLE
Field default value dropdown set empty string

### DIFF
--- a/code/MemberProfileField.php
+++ b/code/MemberProfileField.php
@@ -60,7 +60,7 @@ class MemberProfileField extends DataObject {
 		$fields->removeByName('ProfilePageID');
 
 		$fields->fieldByName('Root.Main')->getChildren()->changeFieldOrder(array(
-			'CustomTitle',
+			'CustomTitle',$
 			'DefaultValue',
 			'Note',
 			'ProfileVisibility',
@@ -93,7 +93,7 @@ class MemberProfileField extends DataObject {
 				_t('MemberProfiles.DEFAULTVALUE', 'Default Value'),
 				$memberField->getSource()
 			));
-			$default->setHasEmptyDefault(true);
+			$default->setEmptyString(' ');
 		} elseif($memberField instanceof TextField) {
 			$fields->replaceField('DefaultValue', new TextField(
 				'DefaultValue', _t('MemberProfiles.DEFAULTVALUE', 'Default Value')

--- a/code/MemberProfileField.php
+++ b/code/MemberProfileField.php
@@ -60,7 +60,7 @@ class MemberProfileField extends DataObject {
 		$fields->removeByName('ProfilePageID');
 
 		$fields->fieldByName('Root.Main')->getChildren()->changeFieldOrder(array(
-			'CustomTitle',$
+			'CustomTitle',
 			'DefaultValue',
 			'Note',
 			'ProfileVisibility',


### PR DESCRIPTION
When a `MemberProfileField` is a `DropdownField` there is no way to select nothing as the default dropdown value. 

`$default->setHasEmptyDefault(true);` doesn't seem to work. 
I have replaced this with `$default->setEmptyString(' ');`.

This allows the user to select the empty string as a default value.