### PR TITLE
Hiding Sort field on MemberProfileField

### DIFF
--- a/code/MemberProfileField.php
+++ b/code/MemberProfileField.php
@@ -58,6 +58,7 @@ class MemberProfileField extends DataObject {
 
 		$fields->removeByName('MemberField');
 		$fields->removeByName('ProfilePageID');
+		$fields->removeByName('Sort');
 
 		$fields->fieldByName('Root.Main')->getChildren()->changeFieldOrder(array(
 			'CustomTitle',


### PR DESCRIPTION
Removing the `Sort` `TextField` from displaying on the `MemberProfileField` field list.