### PR TITLE
FIX Registration form cleared on password validation fail #80

### DIFF
--- a/code/forms/MemberProfileValidator.php
+++ b/code/forms/MemberProfileValidator.php
@@ -61,6 +61,22 @@ class MemberProfileValidator extends RequiredFields {
 				$this->validationError($field, $message, 'required');
 			}
 		}
+		
+		// Create a dummy member as this is required for custom password validators
+		if($data['Password'] !== "") {
+			if(is_null($member)) $member = Member::create();
+
+			if($validator = $member::password_validator()) {
+				$results = $validator->validate($data['Password'], $member);
+
+				if(!$results->valid()) {
+					$valid = false;
+					foreach($results->messageList() as $key => $value) {
+						$this->validationError('Password', $value, 'required');
+					}
+				}
+			}
+		}
 
 		return $valid && parent::php($data);
 	}


### PR DESCRIPTION
This resolves #80.

From what I can tell, the password validation occurs when the POST data is validated by the Member object at `MemberProfilePage->addMember($form)` and NOT at the initial form validation at `MemberProfileValidator->php($data)`, which is why the form completely resets when it redirects back after a password validator fail.

My approach is a bit hacky as a `Member` instance is required to instantiate the password validator (which doesn't exist if the user is just being created) so any feedback is welcome.