### PR TITLE
FIX Validation error on required readonly fields #97

### DIFF
--- a/code/forms/MemberProfileValidator.php
+++ b/code/forms/MemberProfileValidator.php
@@ -19,7 +19,11 @@ class MemberProfileValidator extends RequiredFields {
 		$this->member = $member;
 
 		foreach($this->fields as $field) {
-			if($field->Required) $this->addRequiredField($field->MemberField);
+			if($field->Required) {
+				if($field->ProfileVisibility !== 'Readonly' && Member::currentUser()) {
+					$this->addRequiredField($field->MemberField);
+				}
+			}
 			if($field->Unique)   $this->unique[] = $field->MemberField;
 		}
 


### PR DESCRIPTION
Resolves #97.

Even if a field is readonly and required, the form still attempts to validate it.

The form now checks if the field isn't readonly before setting the field as required.