### PR TITLE
BUG Validator broken on registration form

### DIFF
--- a/code/forms/MemberProfileValidator.php
+++ b/code/forms/MemberProfileValidator.php
@@ -20,7 +20,7 @@ class MemberProfileValidator extends RequiredFields {
 
 		foreach($this->fields as $field) {
 			if($field->Required) {
-				if($field->ProfileVisibility !== 'Readonly' && Member::currentUser()) {
+				if($field->ProfileVisibility !== 'Readonly') {
 					$this->addRequiredField($field->MemberField);
 				}
 			}


### PR DESCRIPTION
Sorry, my last PR broke the validator for required fields on the registration form.

Since the `Member::currentUser()` doesn't exist when registering as no one is logged in, required fields weren't being set at all, allowing the user to bypass required fields completely.

The solution is to remove the check to `Member::currentUser()` as it isn't necessary anyway.