### PR TITLE
fix(MemberProfileValidator): Fix bug where Password still has validation, even though its set 'Hidden'

### DIFF
--- a/code/MemberProfilePage.php
+++ b/code/MemberProfilePage.php
@@ -456,9 +456,14 @@ class MemberProfilePage_Controller extends Page_Controller {
 		$form->loadDataFrom($member);
 
 		if($password = $form->Fields()->fieldByName('Password')) {
-			$password->setCanBeEmpty(false);
-			$password->setValue(null);
-			$password->setCanBeEmpty(true);
+			if ($password->hasMethod('setCanBeEmpty')) {
+				$password->setCanBeEmpty(false);
+				$password->setValue(null);
+				$password->setCanBeEmpty(true);
+			} else {
+				// If Password field is ReadonlyField or similar
+				$password->setValue(null);
+			}
 		}
 
 		return array (

--- a/code/forms/MemberProfileValidator.php
+++ b/code/forms/MemberProfileValidator.php
@@ -67,7 +67,7 @@ class MemberProfileValidator extends RequiredFields {
 		}
 		
 		// Create a dummy member as this is required for custom password validators
-		if($data['Password'] !== "") {
+		if(isset($data['Password']) && $data['Password'] !== "") {
 			if(is_null($member)) $member = Member::create();
 
 			if($validator = $member::password_validator()) {


### PR DESCRIPTION
1st Commit: fix(MemberProfileValidator): Fix bug where Password still has validation, even though its set 'Hidden'

2nd Commit: fix(MemberProfilePage): Fix setting Password to "Readonly" causing it to error on 'setCanBeEmpty' call. Will also fix cases where Password field is swapped out for something without a 'setCanBeEmpty' function.