### PR TITLE
Replaced calls to the deprecated api calls

### DIFF
--- a/src/Forms/MemberProfileValidator.php
+++ b/src/Forms/MemberProfileValidator.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\RequiredFields;
+use SilverStripe\Security\Security;
 
 /**
  * This validator provides the unique and required functionality for {@link MemberProfileField}s.
@@ -87,8 +88,8 @@ class MemberProfileValidator extends RequiredFields
 
                 // This ensures the existing member isn't the same as the current member, in case they're updating information.
 
-                if ($current = Member::currentUserID()) {
-                    $existing = $existing->filter('ID:not', $current);
+                if (Security::getCurrentUser()) {
+                    $existing = $existing->filter('ID:not', Security::getCurrentUser()->ID);
                 }
                 $emailOK = !$existing->first();
             }

--- a/src/Pages/MemberProfilePage.php
+++ b/src/Pages/MemberProfilePage.php
@@ -33,6 +33,7 @@ use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\Security;
 
 /**
  * A MemberProfilePage allows the administratior to set up a page with a subset of the
@@ -180,7 +181,7 @@ class MemberProfilePage extends Page
     public function Link($action = null)
     {
         if (!$action
-            && Member::currentUserID()
+            && Security::getCurrentUser()
             && !$this->AllowProfileEditing
             && $this->CanAddMembers()
         ) {

--- a/src/Pages/MemberProfilePageController.php
+++ b/src/Pages/MemberProfilePageController.php
@@ -84,7 +84,7 @@ class MemberProfilePageController extends PageController
             $session->set('MemberProfile.REDIRECT', $backURL);
         }
 
-        return Member::currentUser() ? $this->indexProfile() : $this->indexRegister();
+        return Security::getCurrentUser() ? $this->indexProfile() : $this->indexRegister();
     }
 
     /**
@@ -133,7 +133,7 @@ class MemberProfilePageController extends PageController
             ));
         }
 
-        $member = Member::currentUser();
+        $member = Security::getCurrentUser();
 
         foreach ($this->Groups() as $group) {
             if (!$member->inGroup($group)) {
@@ -261,7 +261,7 @@ class MemberProfilePageController extends PageController
             new FieldList(
                 new FormAction('save', _t('MemberProfiles.SAVE', 'Save'))
             ),
-            new MemberProfileValidator($this->Fields(), Member::currentUser())
+            new MemberProfileValidator($this->Fields(), Security::getCurrentUser())
         );
         $this->extend('updateProfileForm', $form);
         return $form;
@@ -446,7 +446,7 @@ class MemberProfilePageController extends PageController
             return $this->httpError(400, 'No confirmation required.');
         }
 
-        $currentMember = Member::currentUser();
+        $currentMember = Security::getCurrentUser();
         $id = (int)$request->param('ID');
         $key = $request->getVar('key');
 
@@ -669,8 +669,8 @@ class MemberProfilePageController extends PageController
         $fields        = new FieldList();
 
         // depending on the context, load fields from the current member
-        if (Member::currentUser() && $context != 'Add') {
-            $memberFields = Member::currentUser()->getMemberFormFields();
+        if (Security::getCurrentUser() && $context != 'Add') {
+            $memberFields = Security::getCurrentUser()->getMemberFormFields();
         } else {
             $memberFields = singleton(Member::class)->getMemberFormFields();
         }

--- a/src/Pages/MemberProfileViewer.php
+++ b/src/Pages/MemberProfileViewer.php
@@ -13,6 +13,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Control\Controller;
 use SilverStripe\View\ViewableData;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
 
 /**
  * Handles displaying member's public profiles.
@@ -163,7 +164,7 @@ class MemberProfileViewer extends PageController
             'Type'     => 'View',
             'Member'   => $member,
             'Sections' => $sectionsList,
-            'IsSelf'   => $member->ID == Member::currentUserID()
+            'IsSelf'   => Security::getCurrentUser() && $member->ID == Security::getCurrentUser()->ID,
         ));
 
         return $controller;


### PR DESCRIPTION
This pull request replaces the deprecated api calls `Member::currentUser()` and `Member::currentUserID()` with `Security::getCurrentUser()`.