### PR TITLE
Add class description for MemberProfilePage

### DIFF
--- a/src/Pages/MemberProfilePage.php
+++ b/src/Pages/MemberProfilePage.php
@@ -168,7 +168,7 @@ class MemberProfilePage extends Page
         ]
     ];
 
-    private static $class_description = 'A page for member profile editing.';
+    private static $class_description = 'Allows members to register and edit their profile';
     
     private static $description = '';
 

--- a/src/Pages/MemberProfilePage.php
+++ b/src/Pages/MemberProfilePage.php
@@ -168,6 +168,8 @@ class MemberProfilePage extends Page
         ]
     ];
 
+    private static $class_description = 'A page for member profile editing.';
+    
     private static $description = '';
 
     private static $icon = 'symbiote/silverstripe-memberprofiles: client/images/memberprofilepage.png';


### PR DESCRIPTION
fixes `[User Warning] Missing default for localisation key Symbiote\MemberProfiles\Pages\MemberProfilePage.CLASS_DESCRIPTION`